### PR TITLE
Fix project_protection tests (missing auth header → 403) — unblocks CI image build

### DIFF
--- a/tests/project_protection.rs
+++ b/tests/project_protection.rs
@@ -15,6 +15,7 @@ async fn test_new_project_default_unprotected() {
         .post(format!("{}/project", &app.address))
         .header("Content-Type", "application/json")
         .body(r#"{"custom":{"custom_stack_code":"default-unprot","web":[{"_id":"a1","code":"nginx","name":"Nginx","type":"web","restart":"always","dockerhub_name":"nginx","custom":true}]}}"#)
+        .header("Authorization", format!("Bearer {}", common::USER_A_TOKEN))
         .send()
         .await
         .expect("request failed");
@@ -41,6 +42,7 @@ async fn test_enable_protection_via_patch() {
         ))
         .header("Content-Type", "application/json")
         .body(r#"{"is_protected": true}"#)
+        .header("Authorization", format!("Bearer {}", common::USER_A_TOKEN))
         .send()
         .await
         .expect("request failed");
@@ -65,6 +67,7 @@ async fn test_delete_protected_project_returns_403() {
         ))
         .header("Content-Type", "application/json")
         .body(r#"{"is_protected": true}"#)
+        .header("Authorization", format!("Bearer {}", common::USER_A_TOKEN))
         .send()
         .await
         .expect("request failed");
@@ -73,6 +76,7 @@ async fn test_delete_protected_project_returns_403() {
     // Try to delete — should be blocked
     let resp = client
         .delete(format!("{}/project/{}", &app.address, project_id))
+        .header("Authorization", format!("Bearer {}", common::USER_A_TOKEN))
         .send()
         .await
         .expect("request failed");
@@ -99,6 +103,7 @@ async fn test_delete_unprotected_project_succeeds() {
 
     let resp = client
         .delete(format!("{}/project/{}", &app.address, project_id))
+        .header("Authorization", format!("Bearer {}", common::USER_A_TOKEN))
         .send()
         .await
         .expect("request failed");
@@ -125,6 +130,7 @@ async fn test_disable_protection_requires_name() {
         ))
         .header("Content-Type", "application/json")
         .body(r#"{"is_protected": true}"#)
+        .header("Authorization", format!("Bearer {}", common::USER_A_TOKEN))
         .send()
         .await
         .expect("request failed");
@@ -138,6 +144,7 @@ async fn test_disable_protection_requires_name() {
         ))
         .header("Content-Type", "application/json")
         .body(r#"{"is_protected": false}"#)
+        .header("Authorization", format!("Bearer {}", common::USER_A_TOKEN))
         .send()
         .await
         .expect("request failed");
@@ -164,6 +171,7 @@ async fn test_disable_protection_wrong_name_rejected() {
         ))
         .header("Content-Type", "application/json")
         .body(r#"{"is_protected": true}"#)
+        .header("Authorization", format!("Bearer {}", common::USER_A_TOKEN))
         .send()
         .await
         .expect("request failed");
@@ -177,6 +185,7 @@ async fn test_disable_protection_wrong_name_rejected() {
         ))
         .header("Content-Type", "application/json")
         .body(r#"{"is_protected": false, "confirmation_name": "wrong-name"}"#)
+        .header("Authorization", format!("Bearer {}", common::USER_A_TOKEN))
         .send()
         .await
         .expect("request failed");
@@ -199,6 +208,7 @@ async fn test_disable_protection_correct_name_succeeds() {
         ))
         .header("Content-Type", "application/json")
         .body(r#"{"is_protected": true}"#)
+        .header("Authorization", format!("Bearer {}", common::USER_A_TOKEN))
         .send()
         .await
         .expect("request failed");
@@ -212,6 +222,7 @@ async fn test_disable_protection_correct_name_succeeds() {
         ))
         .header("Content-Type", "application/json")
         .body(r#"{"is_protected": false, "confirmation_name": "Test Project"}"#)
+        .header("Authorization", format!("Bearer {}", common::USER_A_TOKEN))
         .send()
         .await
         .expect("request failed");
@@ -222,6 +233,7 @@ async fn test_disable_protection_correct_name_succeeds() {
     // Now delete should succeed
     let resp = client
         .delete(format!("{}/project/{}", &app.address, project_id))
+        .header("Authorization", format!("Bearer {}", common::USER_A_TOKEN))
         .send()
         .await
         .expect("request failed");
@@ -257,6 +269,7 @@ async fn test_protection_shows_deployment_and_server_counts() {
         ))
         .header("Content-Type", "application/json")
         .body(r#"{"is_protected": true}"#)
+        .header("Authorization", format!("Bearer {}", common::USER_A_TOKEN))
         .send()
         .await
         .expect("request failed");
@@ -265,6 +278,7 @@ async fn test_protection_shows_deployment_and_server_counts() {
     // Try to delete — should be blocked with counts
     let resp = client
         .delete(format!("{}/project/{}", &app.address, project_id))
+        .header("Authorization", format!("Bearer {}", common::USER_A_TOKEN))
         .send()
         .await
         .expect("request failed");
@@ -317,6 +331,7 @@ async fn test_project_list_includes_is_protected() {
         ))
         .header("Content-Type", "application/json")
         .body(r#"{"is_protected": true}"#)
+        .header("Authorization", format!("Bearer {}", common::USER_A_TOKEN))
         .send()
         .await
         .expect("request failed");
@@ -325,6 +340,7 @@ async fn test_project_list_includes_is_protected() {
     // List projects — should include is_protected
     let resp = client
         .get(format!("{}/project", &app.address))
+        .header("Authorization", format!("Bearer {}", common::USER_A_TOKEN))
         .send()
         .await
         .expect("request failed");


### PR DESCRIPTION
## Problem

The 9 `tests/project_protection.rs` integration tests fail (all `403` vs `200`), including basic `POST /project`. They send **no `Authorization` header**, so every request is anonymous → casbin denies → 403. They never passed.

Because `docker.yml` gates the image build on `cargo test`, this **froze `trydirect/stacker:latest`** — which is why the audit feature (`/api/audit/*`) can't be deployed to production (it 404s) and why the agent-gateway PR #202 CI is red.

## Fix

Add `Authorization: Bearer USER_A_TOKEN` before `.send()` on every request (16 of 17; the IDOR test already had one). The single-user mock returns `test_user_id`/`group_user` for any token — matching the `create_test_project` owner and the existing casbin grants (incl. `PATCH /project/:id/protection` from `20260727130000_casbin_project_protection_rule`). Mirrors the passing IDOR test.

## Effect

- `cargo test --test project_protection` should pass → unfreezes the Docker CICD image build → `:latest` rebuilds with the audit routes → production audit deploy unblocked.
- Also clears the same CI failure on PR #202.

Compiles clean (`cargo test --test project_protection --no-run`). Runtime verification is via CI (needs Postgres + the test harness).

🤖 Generated with [Claude Code](https://claude.com/claude-code)